### PR TITLE
#fix 修复读取 json 数据集可能存在的编码报错

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -154,7 +154,7 @@ def collate_fn(batch):
 
 
 train_data = []
-with open("data/qa.json") as file:
+with open("data/qa.json", encoding="utf-8") as file:
     train_data = json.load(file)
 
 from transformers import TrainingArguments, Trainer


### PR DESCRIPTION
```
trainable params: 3670016 || all params: 6258876416 || trainable%: 0.05863697820615348
Traceback (most recent call last):
File "chatglm-finetune\finetune.py", line 157, in
train_data = json.load(file)
File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.3056.0_x64__qbz5n2kfra8p0\lib\json_init_.py", line 293, in load
return loads(fp.read(),
UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 67: illegal multibyte sequence
```