### PR TITLE
#fix 修复 history 无法记录连续聊天的问题

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -12,8 +12,9 @@ model = load_lora_config(model)
 model.load_state_dict(torch.load(f"output/chatglm-6b-lora.pt"), strict=False)
 model.half().cuda().eval()
 
+history = []
+
 while True:
-    history = []
     print("[User]: ")
     msg = input()
     try:


### PR DESCRIPTION
history 列表在 while 里每轮被清空，导致过往聊天记录丢失。